### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :confirm_same_user , only: :edit
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -33,8 +34,20 @@ class ItemsController < ApplicationController
 
   private
 
+
+
   def item_params
     params.require(:item).permit(:category_id, :image, :name, :explain, :category_id, :status_id, :send_cost_id,
                                   :prefecture_id, :send_limit_id, :price).merge(user_id: current_user.id)
+  end
+
+  def confirm_same_user
+    # 出品したユーザーと同じユーザーであるかを確認する
+    if user_signed_in?
+      @item = Item.find(params[:id])
+      if @item.user.id != current_user.id
+        redirect_to item_path
+      end
+    end
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,10 +23,18 @@ class ItemsController < ApplicationController
     @item = Item.new
   end
 
+  def edit
+
+  end
+
+  def update
+    
+  end
+
   private
 
   def item_params
     params.require(:item).permit(:category_id, :image, :name, :explain, :category_id, :status_id, :send_cost_id,
-                                 :prefecture_id, :send_limit_id, :price).merge(user_id: current_user.id)
+                                  :prefecture_id, :send_limit_id, :price).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,7 +29,13 @@ class ItemsController < ApplicationController
   end
 
   def update
-    
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path
+    else
+      render :edit
+    end
+
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :confirm_same_user , only: :edit
+  before_action :confirm_same_user, only: :edit
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -35,12 +35,9 @@ class ItemsController < ApplicationController
     else
       render :edit
     end
-
   end
 
   private
-
-
 
   def item_params
     params.require(:item).permit(:category_id, :image, :name, :explain, :category_id, :status_id, :send_cost_id,
@@ -49,11 +46,9 @@ class ItemsController < ApplicationController
 
   def confirm_same_user
     # 出品したユーザーと同じユーザーであるかを確認する
-    if user_signed_in?
+    unless user_signed_in?
       @item = Item.find(params[:id])
-      if @item.user.id != current_user.id
-        redirect_to item_path
-      end
+      redirect_to item_path if @item.user.id != current_user.id
     end
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,7 +24,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
-
+    @item = Item.find(params[:id])
   end
 
   def update

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,13 +1,13 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :confirm_same_user, only: :edit
+  before_action :confirm_same_user, only: [:edit , :update]
+  before_action :find_user , only: [:show,:edit,:update]
 
   def index
     @items = Item.all.order('created_at DESC')
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def create
@@ -25,11 +25,9 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path
     else
@@ -42,6 +40,10 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:category_id, :image, :name, :explain, :category_id, :status_id, :send_cost_id,
                                   :prefecture_id, :send_limit_id, :price).merge(user_id: current_user.id)
+  end
+
+  def find_user
+    @item = Item.find(params[:id])
   end
 
   def confirm_same_user

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -47,10 +47,6 @@ class ItemsController < ApplicationController
   end
 
   def confirm_same_user
-    # 出品したユーザーと同じユーザーであるかを確認する
-    if user_signed_in?
-      @item = Item.find(params[:id])
-      redirect_to root_path if @item.user.id != current_user.id
-    end
+    redirect_to root_path if @item.user.id != current_user.id
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -46,7 +46,7 @@ class ItemsController < ApplicationController
 
   def confirm_same_user
     # 出品したユーザーと同じユーザーであるかを確認する
-    unless user_signed_in?
+    if user_signed_in?
       @item = Item.find(params[:id])
       redirect_to item_path if @item.user.id != current_user.id
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -48,7 +48,7 @@ class ItemsController < ApplicationController
     # 出品したユーザーと同じユーザーであるかを確認する
     if user_signed_in?
       @item = Item.find(params[:id])
-      redirect_to item_path if @item.user.id != current_user.id
+      redirect_to root_path if @item.user.id != current_user.id
     end
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :find_item , only: [:show,:edit,:update]
   before_action :confirm_same_user, only: [:edit , :update]
-  before_action :find_user , only: [:show,:edit,:update]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -42,7 +42,7 @@ class ItemsController < ApplicationController
                                   :prefecture_id, :send_limit_id, :price).merge(user_id: current_user.id)
   end
 
-  def find_user
+  def find_item
     @item = Item.find(params[:id])
   end
 

--- a/app/javascript/calc_benefit.js
+++ b/app/javascript/calc_benefit.js
@@ -1,22 +1,19 @@
 const calc = () =>{
-  const commission_rate = 0.1 //販売手数料の割合
+  const commission_rate = 0.1 
 
   const root_price = document.getElementById('item-price');
-  const commission = document.getElementById('add-tax-price'); //販売手数料、root_priceの１０％
-  const profit = document.getElementById('profit'); //root_priceから販売手数料を引いた額
+  const commission = document.getElementById('add-tax-price'); 
+  const profit = document.getElementById('profit'); 
 
-  //販売手数料を計算するタイミングで呼び出すもの
   const calculate =  function(){
     commission.innerHTML = Math.floor(root_price.value * commission_rate);
     profit.innerHTML = root_price.value - commission.innerHTML;
   }
 
-  //商品情報編集時、ロード時点で販売手数料などを計算するためのもの
   if(root_price.value != ''){
     calculate();
   };
 
-  //入力時に販売手数料を計算する
   root_price.addEventListener('input' , calculate);
 }
 

--- a/app/javascript/calc_benefit.js
+++ b/app/javascript/calc_benefit.js
@@ -5,11 +5,21 @@ const calc = () =>{
   const commission = document.getElementById('add-tax-price'); //販売手数料、root_priceの１０％
   const profit = document.getElementById('profit'); //root_priceから販売手数料を引いた額
 
-  root_price.addEventListener('input' , ()=>{
+  //販売手数料を計算するタイミングで呼び出すもの
+  const calculate =  function(){
     commission.innerHTML = Math.floor(root_price.value * commission_rate);
     profit.innerHTML = root_price.value - commission.innerHTML;
-  })
+  }
+
+  //商品情報編集時、ロード時点で販売手数料などを計算するためのもの
+  if(root_price.value != ''){
+    calculate();
+  };
+
+  //入力時に販売手数料を計算する
+  root_price.addEventListener('input' , calculate);
 }
+
 
 
 window.addEventListener('load' , calc);

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,6 +1,3 @@
-<%# cssは商品出品のものを併用しています。
-app/assets/stylesheets/items/new.css %>
-
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,0 +1,161 @@
+<%# cssは商品出品のものを併用しています。
+app/assets/stylesheets/items/new.css %>
+
+<div class="items-sell-contents">
+  <header class="items-sell-header">
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+  </header>
+  <div class="items-sell-main">
+    <h2 class="items-sell-title">商品の情報を入力</h2>
+    <%= form_with local: true do |f| %>
+
+    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%# render 'shared/error_messages', model: f.object %>
+    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+
+    <%# 商品画像 %>
+    <div class="img-upload">
+      <div class="weight-bold-text">
+        商品画像
+        <span class="indispensable">必須</span>
+      </div>
+      <div class="click-upload">
+        <p>
+          クリックしてファイルをアップロード
+        </p>
+        <%= f.file_field :hoge, id:"item-image" %>
+      </div>
+    </div>
+    <%# /商品画像 %>
+    <%# 商品名と商品説明 %>
+    <div class="new-items">
+      <div class="weight-bold-text">
+        商品名
+        <span class="indispensable">必須</span>
+      </div>
+      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <div class="items-explain">
+        <div class="weight-bold-text">
+          商品の説明
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+      </div>
+    </div>
+    <%# /商品名と商品説明 %>
+
+    <%# 商品の詳細 %>
+    <div class="items-detail">
+      <div class="weight-bold-text">商品の詳細</div>
+      <div class="form">
+        <div class="weight-bold-text">
+          カテゴリー
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <div class="weight-bold-text">
+          商品の状態
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+      </div>
+    </div>
+    <%# /商品の詳細 %>
+
+    <%# 配送について %>
+    <div class="items-detail">
+      <div class="weight-bold-text question-text">
+        <span>配送について</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div class="form">
+        <div class="weight-bold-text">
+          配送料の負担
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <div class="weight-bold-text">
+          発送元の地域
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <div class="weight-bold-text">
+          発送までの日数
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+      </div>
+    </div>
+    <%# /配送について %>
+
+    <%# 販売価格 %>
+    <div class="sell-price">
+      <div class="weight-bold-text question-text">
+        <span>販売価格<br>(¥300〜9,999,999)</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div>
+        <div class="price-content">
+          <div class="price-text">
+            <span>価格</span>
+            <span class="indispensable">必須</span>
+          </div>
+          <span class="sell-yen">¥</span>
+          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+        </div>
+        <div class="price-content">
+          <span>販売手数料 (10%)</span>
+          <span>
+            <span id='add-tax-price'></span>円
+          </span>
+        </div>
+        <div class="price-content">
+          <span>販売利益</span>
+          <span>
+            <span id='profit'></span>円
+          </span>
+        </div>
+      </div>
+    </div>
+    <%# /販売価格 %>
+
+    <%# 注意書き %>
+    <div class="caution">
+      <p class="sentence">
+        <a href="#">禁止されている出品、</a>
+        <a href="#">行為</a>
+        を必ずご確認ください。
+      </p>
+      <p class="sentence">
+        またブランド品でシリアルナンバー等がある場合はご記載ください。
+        <a href="#">偽ブランドの販売</a>
+        は犯罪であり処罰される可能性があります。
+      </p>
+      <p class="sentence">
+        また、出品をもちまして
+        <a href="#">加盟店規約</a>
+        に同意したことになります。
+      </p>
+    </div>
+    <%# /注意書き %>
+    <%# 下部ボタン %>
+    <div class="sell-btn-contents">
+      <%= f.submit "変更する" ,class:"sell-btn" %>
+      <%=link_to 'もどる', "#", class:"back-btn" %>
+    </div>
+    <%# /下部ボタン %>
+  </div>
+  <% end %>
+
+  <footer class="items-sell-footer">
+    <ul class="menu">
+      <li><a href="#">プライバシーポリシー</a></li>
+      <li><a href="#">フリマ利用規約</a></li>
+      <li><a href="#">特定商取引に関する表記</a></li>
+    </ul>
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <p class="inc">
+      ©︎Furima,Inc.
+    </p>
+  </footer>
+</div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -141,7 +141,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item , url: item_path(@item) , method: :put ,  local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%# render 'shared/error_messages', model: f.object %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -10,7 +10,7 @@ app/assets/stylesheets/items/new.css %>
     <%= form_with model: @item , url: item_path(@item) , method: :put ,  local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: @item %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 商品画像 %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40", value: @item.name %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :explain, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" ,value: @item.explain %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {selected: @item.category_id}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {selected: @item.status_id}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:send_cost_id, SendCost.all, :id, :name, {selected: @item.send_cost_id}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {selected: @item.prefecture_id} , {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:send_limit_id, SendLimit.all, :id, :name, {selected: @item.send_limit_id}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300", value:@item.price %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
     <%# 【購入機能実装時、同時に実装予定】売却済みであれば商品の編集、削除、購入画面に進むのどれも表示しないこと %>
     <% if user_signed_in?  %>
       <% if current_user == @item.user %>
-        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items , only: [:index , :create , :new , :show]
+  resources :items , only: [:index , :create , :new , :show, :edit , :update]
 end


### PR DESCRIPTION
What
--
出品した商品の編集機能の実装

Why
--
ユーザーが、自分が出品した商品の内容を変更することができるようにするため。


画像
--

- ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/52763c23c89253ff1ee27eb20d9fe133

- 必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/d770eaefc072a39b21db19eb14e95ced

- 入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/24b362cc443b25663b4b9e3b958cacac

- 何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/f751413014a99399479678ad9ceb39a3

- ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/40455e66868fdc25ff7ee99903434af9

- ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
まだ商品購入機能は未実装

- ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/5fcafa307a3e1fbc46aeb288492fd8e4

- 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/6b9435dee3e3ecc99682eb0d26050e09
